### PR TITLE
Silence cache warnings in tests

### DIFF
--- a/web/track/config.py
+++ b/web/track/config.py
@@ -59,8 +59,8 @@ class DevelopmentConfig(Config):
 
 
 class TestingConfig(Config):
-
     TESTING = True
+    CACHE_NO_NULL_WARNING = True  # silence Flask-Cache warning
     MONGO_URI = "mongodb://localhost:27017/track_{rand}".format(
         rand=random.randint(0, 1000)
     )


### PR DESCRIPTION
I felt a great disturbance in the Force. As if millions of "UserWarning:
Flask-Cache: CACHE_TYPE is set to null, caching is effectively
disabled." cried out in terror, and were suddenly silenced.