### PR TITLE
Use proper ci image

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.6-alpine
+
+# Python, don't write bytecode!
+ENV PYTHONDONTWRITEBYTECODE 1
+
+RUN apk add --no-cache openssl-dev libffi-dev build-base
+RUN pip install pipenv

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,16 @@
+# CI build image
+
+This folder contains the docker image that is used in the build process.
+You can see it in the cloudbuild.yaml files under the name "track-compliance/ci".
+
+To build a copy of this image:
+
+```sh
+docker build -t gcr.io/track-compliance/ci .
+```
+To push to the registry you will need to configure docker with proper credentials.
+
+```sh
+gcloud auth configure-docker
+docker push gcr.io/track-compliance/ci
+```

--- a/web/cloudbuild.yaml
+++ b/web/cloudbuild.yaml
@@ -12,12 +12,12 @@ steps:
     id: wait
     args: ['mongodb:27017']
 
-  - name: track-compliance/ci
+  - name: 'gcr.io/track-compliance/ci'
     id: install
     entrypoint: pipenv
     args: ['install', '-d']
 
-  - name: track-compliance/ci
+  - name: 'gcr.io/track-compliance/ci'
     id: test
     entrypoint: pipenv
     args: ['run', 'test']


### PR DESCRIPTION
This commit adds a folder with build image used in the CI process, and
references it at its new home on gcr.io.